### PR TITLE
Fix #22 Crash when timeout is not given

### DIFF
--- a/examples/run-command.raku
+++ b/examples/run-command.raku
@@ -1,7 +1,7 @@
 use SSH::LibSSH;
 
 sub MAIN(Str $host, Str $user, Int :$port = 22, Str :$password, Str :$private-key-file, *@command) {
-    my $session = await SSH::LibSSH.connect(:$host, :$user, :$port, :$private-key-file, :$password);
+    my $session = await SSH::LibSSH.connect(:$host, :$user, :$port, :$private-key-file, timeout => 5, :$password);
     my $channel = await $session.execute(@command.join(' '));
     my $exit-code;
     react {

--- a/lib/SSH/LibSSH.rakumod
+++ b/lib/SSH/LibSSH.rakumod
@@ -776,7 +776,8 @@ class SSH::LibSSH {
                         given $state {
                             when Initial {
                                 check-status-code($data);
-                                my $header = "C$mode $to-send.elems() \n";
+                                my $file-name = $local-path.IO.basename;
+                                my $header = "C$mode $to-send.elems() $file-name\n";
                                 $state = SentHeader;
                                 whenever $channel.write($header.encode('utf8-c8')) {}
                             }

--- a/lib/SSH/LibSSH.rakumod
+++ b/lib/SSH/LibSSH.rakumod
@@ -263,7 +263,7 @@ class SSH::LibSSH {
                                     $remove = True;
                                     self!connect-auth-server($v, $scheduler);
                                 }
-                                elsif now - $start-time > $!timeout {
+                                elsif $!timeout && now - $start-time > $!timeout {
                                     $remove = True;
                                     self!teardown-session();
                                     $v.break(X::SSH::LibSSH::Error.new(message => 'Connection timed out'));


### PR DESCRIPTION
Check if timeout is True, because 0 means no timeout at all.
Add default timeout in the run-command example
Minor fix for #20 as scp is deprecated in general and maybe this function should be removed